### PR TITLE
Resolve a few script errors

### DIFF
--- a/common/governments/civics/mut_mutualism_origin.txt
+++ b/common/governments/civics/mut_mutualism_origin.txt
@@ -1,6 +1,4 @@
 origin_mut_mutualism = {
-	max_once_global = yes
-	is_origin = yes
 	icon = "gfx/interface/icons/traits/leader_traits/trait_ruler_expansionist.dds"
 	picture = GFX_origin_mut_mutualism
 

--- a/common/traits/mut_species_traits.txt
+++ b/common/traits/mut_species_traits.txt
@@ -22,7 +22,7 @@ trait_mut_mutualism_secondary = {
 	initial = no
 	modification = yes
 	species_potential_add = { always = no }
-	icon = "gfx/interface/icons/traits/traitclone_soldier.dds"
+	icon = "gfx/interface/icons/traits/trait_clone_soldier.dds"
 	allowed_archetypes = { BIOLOGICAL LITHOID }
 
 	custom_tooltip = trait_mut_mutualism_secondary_effect


### PR DESCRIPTION
It's likely theses 3 script errors were affecting you local copy of CWTools.

There is also an error that `origin_mzilli_exiles` that I did not resolve, but that seems to be a reference to a source mod or work-in-progress.  All remaining warnings are about missing localisation keys, which _shouldn't_ break CWTools.